### PR TITLE
Update to clang 8 and Ubuntu 19.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
-FROM ubuntu:18.04
+FROM ubuntu:19.04
 LABEL maintainer="Joel Luth (joel.luth@gmail.com)"
 LABEL description="clang/llvm build environment"
 
-ENV CLANG_VER 6.0
+ENV CLANG_VER 8
+ENV UBUNTU_VER disco
 
 RUN apt-get update \
 	&& apt-get install -y --no-install-recommends \
@@ -16,7 +17,7 @@ RUN apt-get update \
 	&& rm -rf /var/lib/apt/lists/*
 
 RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
-	&& apt-add-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-${CLANG_VER} main" \
+	&& apt-add-repository "deb http://apt.llvm.org/${UBUNTU_VER}/ llvm-toolchain-${UBUNTU_VER}-${CLANG_VER} main" \
 	&& apt-get update \
 	&& apt-get install -y --no-install-recommends \
 		clang-${CLANG_VER} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ LABEL description="clang/llvm build environment"
 
 ENV CLANG_VER 8
 ENV UBUNTU_VER disco
+ENV CC clang-${CLANG_VER}
 
 RUN apt-get update \
 	&& apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Update clang to latest (8), and while we're at it update the Ubuntu base image